### PR TITLE
Fix star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -726,7 +726,7 @@ Tianhao Wei<sup>1*</sup>, Liqian Ma<sup>12*</sup>, Rui Chen<sup>1</sup>, Weiye Z
 
 <!--## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=zchoi/Awesome-Embodied-Agent-with-LLMs&type=Date)](https://star-history.com/#zchoi/Awesome-Embodied-Agent-with-LLMs&Date)-->
+[![Star History Chart](https://star-history.dera.page/svg?repos=zchoi/Awesome-Embodied-Agent-with-LLMs&type=Date)](https://star-history.dera.page/#zchoi/Awesome-Embodied-Agent-with-LLMs&Date)-->
 
 ## Acknowledge 
 Thanks to everyone who has contributed to this repository! Special thanks to those who submitted PRs with solid work—your efforts make this project better and stronger. 🚀✨


### PR DESCRIPTION
The star history chart in the README is currently broken due to GitHub stargazer API restrictions. This change updates it to a working alternative that uses a different data source requiring no API token, so the chart renders correctly again.